### PR TITLE
Add Xuy CRUD controller and models

### DIFF
--- a/BL/BL.Interfaces/IXuysBL.cs
+++ b/BL/BL.Interfaces/IXuysBL.cs
@@ -1,0 +1,9 @@
+using Entities;
+using Common.SearchParams;
+
+namespace BL.Interfaces
+{
+    public interface IXuysBL : ICrudBL<Xuy, XuysSearchParams, object>
+    {
+    }
+}

--- a/BL/BL.Standard/DependencyInjection.cs
+++ b/BL/BL.Standard/DependencyInjection.cs
@@ -10,6 +10,7 @@ namespace BL.Standard
         {
             services.AddScoped<IUsersBL, UsersBL>();
             services.AddScoped<ITokensBL, TokensBL>();
+            services.AddScoped<IXuysBL, XuysBL>();
 
             return services;
         }

--- a/BL/BL.Standard/XuysBL.cs
+++ b/BL/BL.Standard/XuysBL.cs
@@ -1,0 +1,48 @@
+using BL.Interfaces;
+using Common.SearchParams;
+using Dal.Interfaces;
+using Entities;
+
+namespace BL.Standard
+{
+    public class XuysBL : IXuysBL
+    {
+        private readonly IXuysDal _xuysDal;
+
+        public XuysBL(IXuysDal xuysDal)
+        {
+            _xuysDal = xuysDal;
+        }
+
+        public async Task<int> AddOrUpdateAsync(Xuy entity)
+        {
+            entity.Id = await _xuysDal.AddOrUpdateAsync(entity);
+            return entity.Id;
+        }
+
+        public Task<bool> ExistsAsync(int id)
+        {
+            return _xuysDal.ExistsAsync(id);
+        }
+
+        public Task<bool> ExistsAsync(XuysSearchParams searchParams)
+        {
+            return _xuysDal.ExistsAsync(searchParams);
+        }
+
+        public Task<Xuy> GetAsync(int id, object? convertParams = null)
+        {
+            return _xuysDal.GetAsync(id, convertParams);
+        }
+
+        public Task<bool> DeleteAsync(int id)
+        {
+            return _xuysDal.DeleteAsync(id);
+        }
+
+        public Task<SearchResult<Xuy>> GetAsync(XuysSearchParams searchParams, object? convertParams = null)
+        {
+            return _xuysDal.GetAsync(searchParams, convertParams);
+        }
+    }
+}

--- a/Common/SearchParams/XuysSearchParams.cs
+++ b/Common/SearchParams/XuysSearchParams.cs
@@ -1,0 +1,13 @@
+namespace Common.SearchParams
+{
+    public class XuysSearchParams : BaseSearchParams
+    {
+        public bool? IsActive { get; set; }
+        public XuysSearchParams() { }
+        public XuysSearchParams(bool? isActive = null, string? searchQuery = null, int startIndex = 0, int? objectsCount = null)
+            : base(startIndex, objectsCount, searchQuery)
+        {
+            IsActive = isActive;
+        }
+    }
+}

--- a/Dal/Dal.DbModels/DefaultDbContext.cs
+++ b/Dal/Dal.DbModels/DefaultDbContext.cs
@@ -10,6 +10,7 @@ namespace Dal.DbModels
 
         public virtual DbSet<User> Users { get; set; }
         public virtual DbSet<Token> Tokens { get; set; }
+        public virtual DbSet<Xuy> Xuys { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -26,6 +27,11 @@ namespace Dal.DbModels
                 entity.Property(e => e.Password).IsRequired();
 
                 entity.Property(e => e.RegistrationDate).HasColumnType("datetime");
+            });
+
+            modelBuilder.Entity<Xuy>(entity =>
+            {
+                entity.Property(e => e.Name).IsRequired();
             });
 
             OnModelCreatingPartial(modelBuilder);

--- a/Dal/Dal.DbModels/Xuy.cs
+++ b/Dal/Dal.DbModels/Xuy.cs
@@ -1,0 +1,10 @@
+namespace Dal.DbModels
+{
+    public partial class Xuy
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public bool IsActive { get; set; }
+    }
+}

--- a/Dal/Dal.Interfaces/IXuysDal.cs
+++ b/Dal/Dal.Interfaces/IXuysDal.cs
@@ -1,0 +1,9 @@
+using Common.SearchParams;
+using Dal.DbModels;
+
+namespace Dal.Interfaces
+{
+    public interface IXuysDal : IBaseDal<DefaultDbContext, Xuy, Entities.Xuy, int, XuysSearchParams, object>
+    {
+    }
+}

--- a/Dal/Dal.SQL/DependencyInjection.cs
+++ b/Dal/Dal.SQL/DependencyInjection.cs
@@ -13,6 +13,7 @@ namespace Dal.SQL
             services.AddDbContext<DefaultDbContext>(config => config.UseNpgsql(configuration["ConnectionStrings:DefaultConnectionString"]));
             services.AddScoped<IUsersDal, UsersDal>();
             services.AddScoped<ITokensDal, TokensDal>();
+            services.AddScoped<IXuysDal, XuysDal>();
 
             return services;
         }

--- a/Dal/Dal.SQL/XuysDal.cs
+++ b/Dal/Dal.SQL/XuysDal.cs
@@ -1,0 +1,63 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Dal.DbModels;
+using Dal.Interfaces;
+using Common.SearchParams;
+
+namespace Dal.SQL
+{
+    public class XuysDal : BaseDal<DefaultDbContext, Xuy, Entities.Xuy, int, XuysSearchParams, object>, IXuysDal
+    {
+        protected override bool RequiresUpdatesAfterObjectSaving => false;
+
+        public XuysDal(DefaultDbContext context) : base(context) { }
+
+        protected override Task UpdateBeforeSavingAsync(DefaultDbContext context, Entities.Xuy entity, Xuy dbObject, bool exists)
+        {
+            dbObject.Name = entity.Name;
+            dbObject.Description = entity.Description;
+            dbObject.IsActive = entity.IsActive;
+            return Task.CompletedTask;
+        }
+
+        protected override IQueryable<Xuy> BuildDbQuery(DefaultDbContext context, IQueryable<Xuy> dbObjects, XuysSearchParams searchParams)
+        {
+            if (searchParams.IsActive.HasValue)
+            {
+                dbObjects = dbObjects.Where(item => item.IsActive == searchParams.IsActive.Value);
+            }
+            if (!string.IsNullOrEmpty(searchParams.SearchQuery))
+            {
+                dbObjects = dbObjects.Where(item => item.Name.Contains(searchParams.SearchQuery));
+            }
+            return dbObjects.OrderBy(item => item.Id);
+        }
+
+        protected override async Task<IList<Entities.Xuy>> BuildEntitiesListAsync(DefaultDbContext context, IQueryable<Xuy> dbObjects, object? convertParams, bool isFull)
+        {
+            return (await dbObjects.ToListAsync()).Select(ConvertDbObjectToEntity).ToList();
+        }
+
+        protected override Expression<Func<Xuy, int>> GetIdByDbObjectExpression()
+        {
+            return item => item.Id;
+        }
+
+        protected override Expression<Func<Entities.Xuy, int>> GetIdByEntityExpression()
+        {
+            return item => item.Id;
+        }
+
+        internal static Entities.Xuy ConvertDbObjectToEntity(Xuy dbObject)
+        {
+            if (dbObject == null) throw new ArgumentNullException(nameof(dbObject));
+
+            return new Entities.Xuy(
+                dbObject.Id,
+                dbObject.Name,
+                dbObject.Description,
+                dbObject.IsActive
+            );
+        }
+    }
+}

--- a/DataEncryption/Controllers/XuyController.cs
+++ b/DataEncryption/Controllers/XuyController.cs
@@ -1,0 +1,93 @@
+using BL.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Common.SearchParams;
+using UI.Areas.Public.Models;
+
+namespace DataEncryption.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [ApiExplorerSettings(GroupName = "Xuys")]
+    public class XuyController : ControllerBase
+    {
+        private readonly IXuysBL _xuysBL;
+
+        public XuyController(IXuysBL xuysBL)
+        {
+            _xuysBL = xuysBL;
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpPost("AddOrUpdateXuy")]
+        public async Task<IActionResult> AddOrUpdateXuy([FromBody] XuyModel model)
+        {
+            if (model == null)
+            {
+                return BadRequest("Model is null");
+            }
+
+            var entity = XuyModel.ToEntity(model);
+            if (entity == null)
+            {
+                return BadRequest("Conversion to entity failed");
+            }
+
+            try
+            {
+                var id = await _xuysBL.AddOrUpdateAsync(entity);
+                model.Id = id;
+                return Ok(model);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpGet("GetXuy")]
+        public async Task<IActionResult> GetXuy(int id)
+        {
+            try
+            {
+                var entity = await _xuysBL.GetAsync(id);
+                var model = XuyModel.FromEntity(entity);
+                return Ok(model);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpGet("SearchXuys")]
+        public async Task<IActionResult> SearchXuys([FromQuery] XuysSearchParams searchParams)
+        {
+            try
+            {
+                var result = await _xuysBL.GetAsync(searchParams);
+                var models = XuyModel.FromEntitiesList(result.Objects);
+                return Ok(models);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpDelete("DeleteXuy")]
+        public async Task<IActionResult> DeleteXuy(int id)
+        {
+            try
+            {
+                await _xuysBL.DeleteAsync(id);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+    }
+}

--- a/DataEncryption/Models/XuyModel.cs
+++ b/DataEncryption/Models/XuyModel.cs
@@ -1,0 +1,42 @@
+using Entities;
+
+namespace UI.Areas.Public.Models
+{
+    public class XuyModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public bool IsActive { get; set; }
+
+        public static XuyModel? FromEntity(Xuy obj)
+        {
+            return obj == null ? null : new XuyModel
+            {
+                Id = obj.Id,
+                Name = obj.Name,
+                Description = obj.Description,
+                IsActive = obj.IsActive
+            };
+        }
+
+        public static Xuy? ToEntity(XuyModel obj)
+        {
+            return obj == null ? null : new Xuy(
+                obj.Id,
+                obj.Name,
+                obj.Description,
+                obj.IsActive);
+        }
+
+        public static List<XuyModel> FromEntitiesList(IEnumerable<Xuy> list)
+        {
+            return list?.Select(FromEntity).Where(x => x != null).Cast<XuyModel>().ToList() ?? new List<XuyModel>();
+        }
+
+        public static List<Xuy> ToEntitiesList(IEnumerable<XuyModel> list)
+        {
+            return list?.Select(ToEntity).Where(x => x != null).Cast<Xuy>().ToList() ?? new List<Xuy>();
+        }
+    }
+}

--- a/DataEncryption/Program.cs
+++ b/DataEncryption/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddSwaggerGen(c =>
     c.SwaggerDoc("SymmetricEncryption", new OpenApiInfo { Title = "Symmetric Encryption API", Version = "v1" });
     c.SwaggerDoc("AsymmetricEncryption", new OpenApiInfo { Title = "Asymmetric Encryption API", Version = "v1" });
     c.SwaggerDoc("HashEncryption", new OpenApiInfo { Title = "Hash Encryption API", Version = "v1" });
+    c.SwaggerDoc("Xuys", new OpenApiInfo { Title = "Xuy API", Version = "v1" });
 });
 
 RsaEncryption.GeneratePrivateAndPublicKeys();
@@ -127,7 +128,7 @@ builder.Services.AddSwaggerGen(c =>
         Scheme = "Bearer",
         BearerFormat = "JWT",
         In = ParameterLocation.Header,
-        Description = "Введите токен JWT для авторизации"
+        Description = "Г‚ГўГҐГ¤ГЁГІГҐ ГІГ®ГЄГҐГ­ JWT Г¤Г«Гї Г ГўГІГ®Г°ГЁГ§Г Г¶ГЁГЁ"
     });
 
     c.AddSecurityRequirement(new OpenApiSecurityRequirement
@@ -160,6 +161,7 @@ if (app.Environment.IsDevelopment())
         c.SwaggerEndpoint("/swagger/SymmetricEncryption/swagger.json", "SymmetricEncryption API");
         c.SwaggerEndpoint("/swagger/AsymmetricEncryption/swagger.json", "AsymmetricEncryption API");
         c.SwaggerEndpoint("/swagger/HashEncryption/swagger.json", "HashEncryption API");
+        c.SwaggerEndpoint("/swagger/Xuys/swagger.json", "Xuy API");
     });
 }
 else

--- a/Entities/Xuy.cs
+++ b/Entities/Xuy.cs
@@ -1,0 +1,18 @@
+namespace Entities
+{
+    public class Xuy
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public bool IsActive { get; set; }
+
+        public Xuy(int id, string name, string? description, bool isActive)
+        {
+            Id = id;
+            Name = name;
+            Description = description;
+            IsActive = isActive;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce Xuy entity and DB model
- add Xuys search params
- implement Xuys DAL/BL with DI registrations
- create XuyModel and XuyController for CRUD endpoints
- expose Xuys API in swagger

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841a4d6a8c8832595707d5f6c03fc94